### PR TITLE
Add padding to blog posts

### DIFF
--- a/pages/state-of-the-raid/[post]/index.tsx
+++ b/pages/state-of-the-raid/[post]/index.tsx
@@ -125,6 +125,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
     props: {
       initialData: result,
     },
+    revalidate: 10,
   };
 };
 

--- a/pages/state-of-the-raid/[post]/index.tsx
+++ b/pages/state-of-the-raid/[post]/index.tsx
@@ -1,6 +1,6 @@
 import { Flex, Heading, Text, VStack, Image, Stack, Link, Button } from '@raidguild/design-system';
 import _ from 'lodash';
-import { GetServerSidePropsContext } from 'next';
+import { GetStaticPropsContext } from 'next';
 import { NextSeo } from 'next-seo';
 import { useSession } from 'next-auth/react';
 
@@ -8,7 +8,7 @@ import { FaEdit } from 'react-icons/fa';
 import CMSPageTemplate from '../../../components/page-templates/CMSPageTemplate';
 import PageTitle from '../../../components/page-components/PageTitle';
 import Markdown from '../../../components/atoms/Markdown';
-import { getBlogDetail } from '../../../gql';
+import { getBlogDetail, getBlogsList } from '../../../gql';
 import { getMonthString, checkPermission } from '../../../utils';
 
 type Props = {
@@ -23,6 +23,15 @@ function PostPage({ initialData }: Props) {
   const publishTime = new Date(_.get(initialData, 'createdAt'));
 
   const publishString = `${getMonthString(publishTime)} ${publishTime.getDate()} ${publishTime.getFullYear()}`;
+
+  if (!initialData?.slug) {
+    return (
+      <CMSPageTemplate>
+        <PageTitle title='Page not found' />
+      </CMSPageTemplate>
+    );
+  }
+
   return (
     <CMSPageTemplate>
       <PageTitle title={_.get(initialData, 'title')} />
@@ -66,7 +75,7 @@ function PostPage({ initialData }: Props) {
             | {publishString}
           </Flex>
         </VStack>
-        <Stack background='blackAlpha.800' mt='6' alignItems='flex-start' py='50px'>
+        <Stack background='blackAlpha.800' mt='6' alignItems='flex-start' p='50px'>
           <Heading textAlign='left' as='h1'>
             Abstract
           </Heading>
@@ -91,7 +100,16 @@ function PostPage({ initialData }: Props) {
 //   };
 // }
 
-export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+export const getStaticPaths = async () => {
+  const blogs = (await getBlogsList()) as { slug: string }[];
+
+  return {
+    paths: blogs.map((b) => ({ params: { post: b.slug } })),
+    fallback: true,
+  };
+};
+
+export const getStaticProps = async (context: GetStaticPropsContext) => {
   let post = _.get(context, 'params.post');
   if (_.isArray(post)) post = _.first(post);
 

--- a/pages/state-of-the-raid/index.tsx
+++ b/pages/state-of-the-raid/index.tsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { format } from 'date-fns';
 import { Box, Card, Flex, Heading, Text, VStack, Image, Stack, Button } from '@raidguild/design-system';
 import { FaEdit } from 'react-icons/fa';
 import { useSession } from 'next-auth/react';


### PR DESCRIPTION
- Also now uses static props, rather than server side props (faster loading)

Before:

<img width="1078" alt="Screenshot 2023-07-08 at 6 07 10 PM" src="https://github.com/raid-guild/dot-org-v2/assets/40322776/d05f4c95-ca68-4f46-a161-5d43c838c840">

After:

<img width="981" alt="Screenshot 2023-07-08 at 6 06 49 PM" src="https://github.com/raid-guild/dot-org-v2/assets/40322776/547d74f6-dc7e-4699-8174-b778126c4c29">
