### PR TITLE
Removes unnecessary "important" notice

### DIFF
--- a/components/hire/0-Intro.tsx
+++ b/components/hire/0-Intro.tsx
@@ -56,18 +56,6 @@ const Intro = ({ handleNext, isConnected }: Props) => (
       .
     </Text>
     <br />
-
-    <Flex direction='column' bgColor='primary.500' borderRadius='0.5rem' p='0.5rem 1rem' maxW='720px' color='white'>
-      <Text fontWeight='bold' mb='.5rem' fontFamily='jetbrains'>
-        IMPORTANT
-      </Text>
-      <Text fontFamily='jetbrains'>
-        If you made a bid prior to March 15th, 2022, please use the old version of the Consultation Queue:{' '}
-        <Link href='https://hireus.raidguild.org' isExternal>
-          hireus.raidguild.org
-        </Link>
-      </Text>
-    </Flex>
     <HStack mt='2rem'>
       {!isConnected ? (
         <ConnectWallet label='Sign in to Continue' />


### PR DESCRIPTION
Removes this notice on hire us page:

<img width="858" alt="Screenshot 2023-09-19 at 5 22 56 PM" src="https://github.com/raid-guild/dot-org-v2/assets/40322776/2a03440d-a222-4232-b881-c72f27cdfca1">
